### PR TITLE
Fix long reload commands not being executed in cron mode

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -2132,7 +2132,7 @@ _read_conf() {
       eval "printf \"%s\" \"\$$_sdkey\""
     )"
     if _startswith "$_sdv" "${B64CONF_START}" && _endswith "$_sdv" "${B64CONF_END}"; then
-      _sdv="$(echo "$_sdv" | sed "s/${B64CONF_START}//" | sed "s/${B64CONF_END}//" | _dbase64)"
+      _sdv="$(echo "$_sdv" | sed "s/${B64CONF_START}//" | sed "s/${B64CONF_END}//" | _dbase64 multiline)"
     fi
     printf "%s" "$_sdv"
   else


### PR DESCRIPTION
This ensures config values longer than the base64 single line limit are
properly decoded when reading via _readdomainconf. Previously, these
string would be read as empty values, and in the case of the reload
command, it was not being executed during cron mode.